### PR TITLE
Simulation cutoffs

### DIFF
--- a/pystablemotifs/AttractorRepertoire.py
+++ b/pystablemotifs/AttractorRepertoire.py
@@ -60,7 +60,7 @@ class AttractorRepertoire:
         self.relevant_nodes = None
 
     @classmethod
-    def from_primes(cls,primes,max_simulate_size=20,max_stable_motifs=10000,MPBN_update=False):
+    def from_primes(cls,primes,max_simulate_size=20,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
         """Build the succession diagram and attractor repertoire from pyboolnet
         formatted update rules rules.
 
@@ -74,6 +74,11 @@ class AttractorRepertoire:
         max_stable_motifs : int
             Maximum number of output lines for pyboolnet to process from the
             AspSolver (the default is 10000).
+        max_in_degree : int or float
+            Will not try to delete nodes that will result an increase in the
+            in-degree of the downstream node so that it has in-degree larger than this.
+            Deleting nodes with large in-degree can be computationally expensive (the default
+            is float('inf')).
         MPBN_update : bool
             Whether MBPN update is used instead of general asynchronous update
             (see L Pauleve, J Kolcak, T Chatain, S Haar, "Reconciling qualitative, abstract, and scalable modeling of biological networks." Nat. Com. vol. 11, no. 4256 (2020))
@@ -87,7 +92,7 @@ class AttractorRepertoire:
         """
         x = cls()
         x.primes = primes
-        x.analyze_system(primes,max_simulate_size=max_simulate_size,max_stable_motifs=max_stable_motifs,MPBN_update=MPBN_update)
+        x.analyze_system(primes,max_simulate_size=max_simulate_size,max_stable_motifs=max_stable_motifs,max_in_degree=max_in_degree,MPBN_update=MPBN_update)
         x.simplify_diagram([], merge_equivalent_reductions = False)
         return x
 
@@ -159,7 +164,7 @@ class AttractorRepertoire:
                     # ludicrously conservative upper bound; assumes STG is all 2-cycles
                     self.most_attractors += 2**(attractor.n_unfixed - 1)
 
-    def analyze_system(self,primes,max_simulate_size=20,max_stable_motifs=10000,MPBN_update=False):
+    def analyze_system(self,primes,max_simulate_size=20,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
         """Build and process the succession diagram for the model.
 
         Parameters
@@ -172,12 +177,17 @@ class AttractorRepertoire:
         max_stable_motifs : int
             Maximum number of output lines for pyboolnet to process from the
             AspSolver (the default is 10000).
+        max_in_degree : int or float
+            Will not try to delete nodes that will result an increase in the
+            in-degree of the downstream node so that it has in-degree larger than this.
+            Deleting nodes with large in-degree can be computationally expensive (the default
+            is float('inf')).
         MPBN_update : bool
             Whether MBPN update is used instead of general asynchronous update
             (see Pauleve et al. 2020)(the default is False).
 
         """
-        self.succession_diagram = sm_succession.build_succession_diagram(primes,max_simulate_size=max_simulate_size,max_stable_motifs=max_stable_motifs,MPBN_update=MPBN_update)
+        self.succession_diagram = sm_succession.build_succession_diagram(primes,max_simulate_size=max_simulate_size,max_stable_motifs=max_stable_motifs,max_in_degree=max_in_degree,MPBN_update=MPBN_update)
         self._get_attractors_from_succession_diagram()
         self._count_attractors()
 

--- a/pystablemotifs/AttractorRepertoire.py
+++ b/pystablemotifs/AttractorRepertoire.py
@@ -60,7 +60,7 @@ class AttractorRepertoire:
         self.relevant_nodes = None
 
     @classmethod
-    def from_primes(cls,primes,max_simulate_size=20,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
+    def from_primes(cls,primes,max_simulate_size=20,max_simulate_size_vc=None,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
         """Build the succession diagram and attractor repertoire from pyboolnet
         formatted update rules rules.
 
@@ -71,6 +71,9 @@ class AttractorRepertoire:
         max_simulate_size : int
             Maximum number of variables for which to brute-force build a state
             transition graph (the default is 20).
+        max_simulate_size_vc : int
+            Maximum number of variables for which to brute-force build a state
+            transition graph for the vc-reduced space (the default is the same as max_simulate_size).
         max_stable_motifs : int
             Maximum number of output lines for pyboolnet to process from the
             AspSolver (the default is 10000).
@@ -92,7 +95,7 @@ class AttractorRepertoire:
         """
         x = cls()
         x.primes = primes
-        x.analyze_system(primes,max_simulate_size=max_simulate_size,max_stable_motifs=max_stable_motifs,max_in_degree=max_in_degree,MPBN_update=MPBN_update)
+        x.analyze_system(primes,max_simulate_size=max_simulate_size,max_simulate_size_vc=max_simulate_size_vc,max_stable_motifs=max_stable_motifs,max_in_degree=max_in_degree,MPBN_update=MPBN_update)
         x.simplify_diagram([], merge_equivalent_reductions = False)
         return x
 
@@ -164,7 +167,7 @@ class AttractorRepertoire:
                     # ludicrously conservative upper bound; assumes STG is all 2-cycles
                     self.most_attractors += 2**(attractor.n_unfixed - 1)
 
-    def analyze_system(self,primes,max_simulate_size=20,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
+    def analyze_system(self,primes,max_simulate_size=20,max_simulate_size_vc=None,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
         """Build and process the succession diagram for the model.
 
         Parameters
@@ -174,6 +177,9 @@ class AttractorRepertoire:
         max_simulate_size : int
             Maximum number of variables for which to brute-force build a state
             transition graph (the default is 20).
+        max_simulate_size_vc : int
+            Maximum number of variables for which to brute-force build a state
+            transition graph for the vc-reduced space (the default is the same as max_simulate_size).
         max_stable_motifs : int
             Maximum number of output lines for pyboolnet to process from the
             AspSolver (the default is 10000).
@@ -187,7 +193,7 @@ class AttractorRepertoire:
             (see Pauleve et al. 2020)(the default is False).
 
         """
-        self.succession_diagram = sm_succession.build_succession_diagram(primes,max_simulate_size=max_simulate_size,max_stable_motifs=max_stable_motifs,max_in_degree=max_in_degree,MPBN_update=MPBN_update)
+        self.succession_diagram = sm_succession.build_succession_diagram(primes,max_simulate_size=max_simulate_size,max_simulate_size_vc=max_simulate_size_vc,max_stable_motifs=max_stable_motifs,max_in_degree=max_in_degree,MPBN_update=MPBN_update)
         self._get_attractors_from_succession_diagram()
         self._count_attractors()
 

--- a/pystablemotifs/drivers.py
+++ b/pystablemotifs/drivers.py
@@ -123,7 +123,7 @@ def logical_domain_of_influence(partial_state,primes,implied_hint=None,contradic
     return implied, contradicted
 
 def domain_of_influence(partial_state,primes,implied_hint=None,contradicted_hint=None,
-    max_simulate_size=20,max_stable_motifs=10000,MPBN_update=False):
+    max_simulate_size=20,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
     """Computes the domain of influence (DOI) of the seed set. (see Yang et al. 2018)
 
     Parameters
@@ -142,6 +142,11 @@ def domain_of_influence(partial_state,primes,implied_hint=None,contradicted_hint
     max_stable_motifs : int
         Maximum number of output lines for pyboolnet to process from the
         AspSolver (the default is 10000).
+    max_in_degree : int or float
+        Will not try to delete nodes that will result an increase in the
+        in-degree of the downstream node so that it has in-degree larger than this.
+        Deleting nodes with large in-degree can be computationally expensive (the default
+        is float('inf')).
     MPBN_update : bool
         Whether MBPN update is used instead of general asynchronous update
         (see Pauleve et al. 2020)(the default is False).
@@ -210,7 +215,7 @@ def domain_of_influence(partial_state,primes,implied_hint=None,contradicted_hint
         ar = sorted_attractor_dict_list
     else:
         ar = sm.AttractorRepertoire.from_primes(primes_to_search,max_simulate_size=max_simulate_size,
-            max_stable_motifs=max_stable_motifs,MPBN_update=MPBN_update)
+            max_stable_motifs=max_stable_motifs,max_in_degree=max_in_degree,MPBN_update=MPBN_update)
         attractor_dict_list = []
         for attractor in ar.attractors:
             attractor_dict_list.append(attractor.attractor_dict)

--- a/pystablemotifs/drivers.py
+++ b/pystablemotifs/drivers.py
@@ -123,7 +123,7 @@ def logical_domain_of_influence(partial_state,primes,implied_hint=None,contradic
     return implied, contradicted
 
 def domain_of_influence(partial_state,primes,implied_hint=None,contradicted_hint=None,
-    max_simulate_size=20,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
+    max_simulate_size=20,max_simulate_size_vc=None,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
     """Computes the domain of influence (DOI) of the seed set. (see Yang et al. 2018)
 
     Parameters
@@ -139,6 +139,9 @@ def domain_of_influence(partial_state,primes,implied_hint=None,contradicted_hint
     max_simulate_size : int
         Maximum number of variables for which to brute-force build a state
         transition graph (the default is 20).
+    max_simulate_size_vc : int
+        Maximum number of variables for which to brute-force build a state
+        transition graph for the vc-reduced space (the default is the same as max_simulate_size).
     max_stable_motifs : int
         Maximum number of output lines for pyboolnet to process from the
         AspSolver (the default is 10000).
@@ -214,7 +217,8 @@ def domain_of_influence(partial_state,primes,implied_hint=None,contradicted_hint
             sorted_attractor_dict_list.append(dict(sorted(attractor.items())))
         ar = sorted_attractor_dict_list
     else:
-        ar = sm.AttractorRepertoire.from_primes(primes_to_search,max_simulate_size=max_simulate_size,
+        ar = sm.AttractorRepertoire.from_primes(primes_to_search,
+            max_simulate_size=max_simulate_size,max_simulate_size_vc=max_simulate_size_vc,
             max_stable_motifs=max_stable_motifs,max_in_degree=max_in_degree,MPBN_update=MPBN_update)
         attractor_dict_list = []
         for attractor in ar.attractors:

--- a/pystablemotifs/reduction.py
+++ b/pystablemotifs/reduction.py
@@ -305,6 +305,9 @@ class MotifReduction:
     max_simulate_size : int
         Maximum number of variables for which to brute-force build a state
         transition graph (the default is 20).
+    max_simulate_size_vc : int
+        Maximum number of variables for which to brute-force build a state
+        transition graph for the vc-reduced space (the default is the same as max_simulate_size).
     prioritize_source_motifs : bool
         Whether source nodes should be considered first (the default is True).
     max_stable_motifs : int
@@ -396,7 +399,10 @@ class MotifReduction:
         an upper bound on the number of motif avoidant attractors in the reduction.
     """
 
-    def __init__(self,motif_history,fixed,reduced_primes,max_simulate_size=20,prioritize_source_motifs=True,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
+    def __init__(self,motif_history,fixed,reduced_primes,max_simulate_size=20,max_simulate_size_vc=None,prioritize_source_motifs=True,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
+        if max_simulate_size_vc == None:
+            max_simulate_size_vc = max_simulate_size
+
         if motif_history is None:
             self.motif_history = []
         else:
@@ -517,7 +523,7 @@ class MotifReduction:
                         #print("The reduction indicates that the branch is not terminal. No need to simulate.")
                         self.attractor_dict_list = self.generate_attr_dict_list()
                         return
-                if len(self.delprimes) < max_simulate_size:
+                if len(self.delprimes) < max_simulate_size_vc:
                     #print("Simulating deletion reduction ("+str(len(self.delprimes))+" nodes)...")
                     self.find_deletion_no_motif_attractors(max_stable_motifs=max_stable_motifs)
                     if len(self.deletion_no_motif_attractors) == 0 and self.terminal != "yes":

--- a/pystablemotifs/succession.py
+++ b/pystablemotifs/succession.py
@@ -452,7 +452,7 @@ class SuccessionDiagram:
 
         return nonredundant_drivers
 
-def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=None, merge_equivalent_motifs=True,max_simulate_size=20,prioritize_source_motifs=True,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
+def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=None, merge_equivalent_motifs=True,max_simulate_size=20,max_simulate_size_vc=None,prioritize_source_motifs=True,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
     """Recursively construct a succession diagram from the input update rules.
     Generally, it is preferable to construct this from within the AttractorRepertoire
     class (using, e.g., AttractorRepertoire.from_primes).
@@ -479,6 +479,9 @@ def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=Non
     max_simulate_size : int
         Maximum number of variables for which to brute-force build a state
         transition graph (the default is 20).
+    max_simulate_size_vc : int
+        Maximum number of variables for which to brute-force build a state
+        transition graph for the vc-reduced space (the default is the same as max_simulate_size).
     prioritize_source_motifs : bool
         Whether source nodes should be considered first (the default is True).
     max_stable_motifs : int
@@ -509,7 +512,7 @@ def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=Non
     myMotifReductionToCopy = diagram.find_equivalent_reduction(fixed)
 
     if myMotifReductionToCopy is None:
-        myMotifReduction=sm_reduction.MotifReduction(motif_history,fixed.copy(),primes,max_simulate_size=max_simulate_size,prioritize_source_motifs=prioritize_source_motifs,max_stable_motifs=max_stable_motifs,MPBN_update=MPBN_update)
+        myMotifReduction=sm_reduction.MotifReduction(motif_history,fixed.copy(),primes,max_simulate_size=max_simulate_size,max_simulate_size_vc=max_simulate_size_vc,prioritize_source_motifs=prioritize_source_motifs,max_stable_motifs=max_stable_motifs,MPBN_update=MPBN_update)
     else:
         myMotifReduction = deepcopy(myMotifReductionToCopy)
         myMotifReduction.motif_history = motif_history.copy()
@@ -535,6 +538,7 @@ def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=Non
             diagram = build_succession_diagram(np,fixed3,myMotifReduction.motif_history+[sm],
                 diagram, merge_equivalent_motifs=merge_equivalent_motifs,
                 max_simulate_size=max_simulate_size,
+                max_simulate_size_vc=max_simulate_size_vc,
                 max_stable_motifs=max_stable_motifs,
                 prioritize_source_motifs=prioritize_source_motifs,
                 max_in_degree=max_in_degree,

--- a/pystablemotifs/succession.py
+++ b/pystablemotifs/succession.py
@@ -452,7 +452,7 @@ class SuccessionDiagram:
 
         return nonredundant_drivers
 
-def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=None, merge_equivalent_motifs=True,max_simulate_size=20,prioritize_source_motifs=True,max_stable_motifs=10000, MPBN_update=False):
+def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=None, merge_equivalent_motifs=True,max_simulate_size=20,prioritize_source_motifs=True,max_stable_motifs=10000,max_in_degree=float('inf'),MPBN_update=False):
     """Recursively construct a succession diagram from the input update rules.
     Generally, it is preferable to construct this from within the AttractorRepertoire
     class (using, e.g., AttractorRepertoire.from_primes).
@@ -484,6 +484,11 @@ def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=Non
     max_stable_motifs : int
         Maximum number of output lines for pyboolnet to process from the
         AspSolver (the default is 10000).
+    max_in_degree : int or float
+        Will not try to delete nodes that will result an increase in the
+        in-degree of the downstream node so that it has in-degree larger than this.
+        Deleting nodes with large in-degree can be computationally expensive (the default
+        is float('inf')).
     MPBN_update : bool
         Whether MBPN update is used instead of general asynchronous update
         (the default is False).
@@ -532,5 +537,6 @@ def build_succession_diagram(primes, fixed=None, motif_history=None, diagram=Non
                 max_simulate_size=max_simulate_size,
                 max_stable_motifs=max_stable_motifs,
                 prioritize_source_motifs=prioritize_source_motifs,
+                max_in_degree=max_in_degree,
                 MPBN_update=MPBN_update)
     return diagram


### PR DESCRIPTION
#28 Simulation cutoffs

max_simulation_size_vc was added to class MotifReduction in reduction.py and every function/class that calls it.
Maximum number of variables for which to brute-force build a state transition graph for the vc-reduced space (the default is the same as max_simulate_size).

max_in_degree parameter was added to deletion_reduction() in reduction.py and every function/class that calls it.
Will not try to delete nodes that will result an increase in the in-degree of the downstream node so that it has in-degree larger than this. (the default is float('inf')).