### PR TITLE
Update reduction.py

### DIFF
--- a/pystablemotifs/reduction.py
+++ b/pystablemotifs/reduction.py
@@ -1033,7 +1033,7 @@ class MotifReduction:
             #there are complex attractors mapped out:
             attr_list=[]
             for complex_attractor in self.no_motif_attractors:
-                ca_dict = sm_format.statelist2dict(non_fixed_nodes,complex_attractor)
+                ca_dict = sm_format.statelist2dict(sorted(self.reduced_primes),complex_attractor)
                 ns = node_state_dict.copy()
                 ns.update(ca_dict)
                 ns = {k:v for k,v in sorted(ns.items())}


### PR DESCRIPTION
This should fix #94. Basically, the convention in the partial STG construction is to use all nodes of the reduced network when labeling states, even the ones we know will be fixed based on the r-space calculations. When figuring out which nodes get fixed by oscillation, we used the wrong convention for converting this string to a dictionary, resulting in the error reported in #94.